### PR TITLE
Use svgo ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "babylon": "^6.18.0",
     "lodash.isplainobject": "^4.0.6",
     "resolve-from": "^2.0.0",
-    "svgo": "^0.7.2"
+    "svgo": "^1.0.3"
   }
 }


### PR DESCRIPTION
svgo is on 1.0.3 now, so let's get on a newer version.

I'm not sure if there is anything else needed for this change.

https://github.com/svg/svgo/releases/tag/v1.0.0