### PR TITLE
Add svgo: false test case

### DIFF
--- a/test/sanity.js
+++ b/test/sanity.js
@@ -33,6 +33,21 @@ transformFile('test/fixtures/test-import.jsx', {
   console.log('test/fixtures/test-import.jsx', result.code);
 });
 
+transformFile('test/fixtures/test-import.jsx', {
+  babelrc: false,
+  presets: ['react'],
+  plugins: [
+    ['../../src/index', {
+      svgo: false,
+    }],
+  ],
+}, (err, result) => {
+  if (err) throw err;
+  assertReactImport(result);
+  validateDefaultProps(result);
+  console.log('test/fixtures/test-import.jsx', result.code);
+});
+
 transformFile('test/fixtures/test-multiple-svg.jsx', {
   babelrc: false,
   presets: ['@babel/preset-react'],


### PR DESCRIPTION
This checks if the build passes when svgo is turned off.

Notably, it currently doesn't! 🎉 That is due to the xml tag in our example svgs. I don't know if that's invalid syntax or not but it *does* break. 

to: @ljharb 