### PR TITLE
[Fix] Register module binding

### DIFF
--- a/test/fixtures/test-no-duplicate-react.jsx
+++ b/test/fixtures/test-no-duplicate-react.jsx
@@ -1,0 +1,5 @@
+import MySvg from './close.svg';
+
+export function MyFunctionIcon() {
+  return MySvg;
+}

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -58,6 +58,30 @@ transformFile('test/fixtures/test-no-react.jsx', {
   validateDefaultProps(result);
 });
 
+transformFile('test/fixtures/test-no-duplicate-react.jsx', {
+  babelrc: false,
+  presets: ['@babel/preset-react'],
+  plugins: [
+    inlineReactSvgPlugin,
+    ({
+      visitor: {
+        Program: {
+          exit({ scope }) {
+            if (!scope.hasBinding('React')) {
+              throw new Error('React binding was expected.');
+            }
+          },
+        },
+      },
+    }),
+  ],
+}, (err, result) => {
+  if (err) throw err;
+  console.log('test/fixtures/test-no-duplicate-react.jsx', result.code);
+  assertReactImport(result);
+  validateDefaultProps(result);
+});
+
 if (fs.existsSync(path.resolve('./PACKAGE.JSON'))) {
   transformFile('test/fixtures/test-case-sensitive.jsx', {
     babelrc: false,
@@ -71,7 +95,7 @@ if (fs.existsSync(path.resolve('./PACKAGE.JSON'))) {
     if (err && err.message.indexOf('match case') !== -1) {
       console.log('test/fixtures/test-case-sensitive.jsx', 'Test passed: Expected case sensitive error was thrown');
     } else {
-      throw new Error('Test failed: Expected case sensitive error wasn‘t thrown, got: ' + err.message);
+      throw new Error(`Test failed: Expected case sensitive error wasn‘t thrown, got: ${err.message}`);
     }
   });
 } else {


### PR DESCRIPTION
This pull requests registers the React import added by this plugin. This is necessary as Babel [does not automatically detect new bindings](https://github.com/babel/babel/issues/8358#issuecomment-511196347).

As a result, two or more Babel plugins can implement this behavior and all rely on `path.scope.hasBinding('React')` to prevent duplication.

I eliminated the destructuring assignment as `unshiftContainer` relies on `this` (`path`).

Also added a test that ensures the binding is present.

---

Fixes https://github.com/airbnb/babel-plugin-inline-react-svg/issues/50