### PR TITLE
Support React JSX automatic transform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default declare(({
     if (typeof importPath !== 'string') {
       throw new TypeError('`applyPlugin` `importPath` must be a string');
     }
-    const { ignorePattern, caseSensitive, filename: providedFilename } = state.opts;
+    const { ignorePattern, caseSensitive, filename: providedFilename, noReactAutoImport } = state.opts;
     const { file, filename } = state;
     if (ignorePattern) {
       // Only set the ignoreRegex once:
@@ -130,7 +130,7 @@ export default declare(({
           if (typeof filename === 'undefined' && typeof opts.filename !== 'string') {
             throw new TypeError('the "filename" option is required when transforming code');
           }
-          if (!path.scope.hasBinding('React')) {
+          if (!opts.noReactAutoImport && !path.scope.hasBinding('React')) {
             const reactImportDeclaration = t.importDeclaration([
               t.importDefaultSpecifier(t.identifier('React')),
             ], t.stringLiteral('react'));


### PR DESCRIPTION
The React JSX transform detects JSX by seeing if it's already in the file, but it won't know about transformed JSX if the node visitors were never hit.

https://github.com/babel/babel/blob/02fc9e835ceac71eb4de7dac6137fd0489176c29/packages/babel-helper-builder-react-jsx-experimental/src/index.js#L328

This new functionality can be enabled with `noReactAutoImport: true` in `.babelrc`.