### PR TITLE
Fix crash when SVGO is turned off

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/parser": "^7.0.0",
     "lodash.isplainobject": "^4.0.6",
     "resolve": "^1.20.0",
-    "svgo": "^2.0.0"
+    "svgo": "^2.0.3"
   },
   "engines": {
     "node": ">=10.13"

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export default declare(({
       }
       const rawSource = readFileSync(svgPath, 'utf8');
       const optimizedSource = state.opts.svgo === false
-        ? rawSource
+        ? { data: rawSource }
         : optimize(rawSource, state.opts.svgo);
 
       const escapeSvgSource = escapeBraces(optimizedSource);


### PR DESCRIPTION
## Purpose

The plugin crashes when SVGO is turned off (e.g. `[['inline-react-svg', { svgo: false }]]`). Here's the error message:

```
/home/runner/work/icons/icons/node_modules/babel-plugin-inline-react-svg/lib/escapeBraces.js:24
    data: raw.data.replace(/(\{|\})/g, '{`$1`}')
```

<details>
<summary>Full stack trace</summary>

```
TypeError: /home/runner/work/icons/icons/AddItemFilled.js: Cannot read property 'replace' of undefined
    at escapeBraces (/home/runner/work/icons/icons/node_modules/babel-plugin-inline-react-svg/lib/escapeBraces.js:24:20)
    at applyPlugin (/home/runner/work/icons/icons/node_modules/babel-plugin-inline-react-svg/lib/index.js:112:58)
    at PluginPass.ImportDeclaration (/home/runner/work/icons/icons/node_modules/babel-plugin-inline-react-svg/lib/index.js:199:11)
    at newFn (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/visitors.js:175:21)
    at NodePath._call (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/path/context.js:55:20)
    at NodePath.call (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/path/context.js:42:17)
    at NodePath.visit (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/path/context.js:92:31)
    at TraversalContext.visitQueue (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/context.js:116:16)
    at TraversalContext.visitMultiple (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/context.js:80:17)
    at TraversalContext.visit (/home/runner/work/icons/icons/node_modules/@babel/traverse/lib/context.js:142:19)
```

</details>

## Approach & Changes

- wrap raw source in an object to match the return format from SVGO


**Note:** PR https://github.com/airbnb/babel-plugin-inline-react-svg/pull/49 which adds a test for this use case should be merged alongside this to prevent future regressions.