### PR TITLE
Update `svgo` configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,42 @@ npm install --save-dev babel-plugin-inline-react-svg
         "svgo": {
           "plugins": [
             {
-              "removeAttrs": { "attrs": "(data-name)" }
+              "name": "removeAttrs", 
+              "params": { "attrs": "(data-name)" }
             },
-            {
-              "cleanupIDs": true
-            }
+            "cleanupIDs"
           ]
-
         }
       }
     ]
   ]
 }
 
+```
+
+**Note:** If `plugins` field is specified the default enabled `svgo` plugins will be overrided. Alternatively, if your Babel config is in JavaScript, the default list of plugins can be extended by making use of the `extendDefaultPlugins` utility provided by `svgo`.
+
+```js
+const { extendDefaultPlugins } = require('svgo');
+
+module.exports = {
+  plugins: [
+    [
+      'inline-react-svg',
+      {
+        svgo: {
+          plugins: extendDefaultPlugins([
+            {
+              name: 'removeAttrs',
+              params: { attrs: '(data-name)' }
+            },
+            'cleanupIDs',
+          ])
+        }
+      }
+    ]
+  ]
+}
 ```
 
 ### Via CLI


### PR DESCRIPTION
Updates the syntax used to configure `svgo` v2 plugins. Also adds an example showing how to extend the list of default enabled `svgo` plugins.

Instructions to configure plugins can be seen [here](https://github.com/svg/svgo/blob/v2.1.0/README.md#configuration).

Closes #102.