### PR TITLE
Fix for Invalid attribute name: aria-

### DIFF
--- a/src/transformSvg.js
+++ b/src/transformSvg.js
@@ -44,9 +44,9 @@ export default (t) => ({
       // <svg stroke-width="5">
       // to
       // <svg strokeWidth="5">
-      // don't convert any custom data-* or aria-* attributes just wrap in quotes
+      // don't convert any custom data-* or aria-* attributes
       if (/^data-|^aria-/.test(originalName.name)) {
-        originalName.name = `'${originalName.name}'`;
+        originalName.name = originalName.name;
       } else {
         originalName.name = hyphenToCamel(originalName.name);
       }


### PR DESCRIPTION
ASAP

There is an error message in a console and react removes aria-labelledby because it's wrapped in single ticks:

 Warning: Invalid attribute name: `'aria-labelledby'`