### PR TITLE
Support for generating SVG components without `.defaultProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npm install --save-dev babel-plugin-inline-react-svg
 
 - `ignorePattern` - A pattern that imports will be tested against to selectively ignore imports.
 - `caseSensitive` - A boolean value that if true will require file paths to match with case-sensitivity. Useful to ensure consistent behavior if working on both a case-sensitive operating system like Linux and a case-insensitive one like OS X or Windows.
+- `emitDeprecatedDefaultProps` - A boolean value that if true will make the package keep emitting the [deprecated](https://github.com/facebook/react/pull/16210) `.defaultProps` declaration for the generated SVG components 
 - `svgo` - svgo options (`false` to disable). Example:
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/parser": "^7.0.0",
     "lodash.isplainobject": "^4.0.6",
+    "object.assign": "^4.1.5",
     "resolve": "^2.0.0-next.5",
     "svgo": "^2.8.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -46,11 +46,17 @@ export default declare(({
 
     if (SVG_NAME !== 'default') {
       return template(namedTemplate)({
-        SVG_NAME, SVG_CODE, SVG_DEFAULT_PROPS_CODE, PROPS_NAME,
+        SVG_NAME,
+        SVG_CODE,
+        SVG_DEFAULT_PROPS_CODE,
+        PROPS_NAME,
       });
     }
     return template(anonymousTemplate)({
-      SVG_CODE, SVG_DEFAULT_PROPS_CODE, EXPORT_FILENAME, PROPS_NAME,
+      SVG_CODE,
+      SVG_DEFAULT_PROPS_CODE,
+      EXPORT_FILENAME,
+      PROPS_NAME,
     });
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,6 @@ export default declare(({
     const PROPS_NAME = SVG_DEFAULT_PROPS_CODE ? 'overrides' : 'props';
 
     const namedTemplate = `
-      ${SVG_DEFAULT_PROPS_CODE ? '' : ''}
       var SVG_NAME = function SVG_NAME(PROPS_NAME) { ${defaultProps} return SVG_CODE; };
       ${SVG_DEFAULT_PROPS_CODE && EMIT_DEPRECATED_DEFAULT_PROPS ? 'SVG_NAME.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
       ${IS_EXPORT ? 'export { SVG_NAME };' : ''}

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default declare(({
     EMIT_DEPRECATED_DEFAULT_PROPS,
   }) => {
     const defaultProps = SVG_DEFAULT_PROPS_CODE
-      ? 'var props = objectAssign({}, SVG_DEFAULT_PROPS_CODE, overrides);'
+      ? 'var props = objectAssignShim()({}, SVG_DEFAULT_PROPS_CODE, overrides);'
       : '';
     const PROPS_NAME = SVG_DEFAULT_PROPS_CODE ? 'overrides' : 'props';
 
@@ -164,10 +164,10 @@ export default declare(({
             throw new TypeError('the "filename" option is required when transforming code');
           }
 
-          if (!path.scope.hasBinding('object.assign/implementation')) {
+          if (!path.scope.hasBinding('object.assign/shim')) {
             const assignDeclaration = t.importDeclaration([
-              t.importDefaultSpecifier(t.identifier('objectAssign')),
-            ], t.stringLiteral('object.assign/implementation'));
+              t.importDefaultSpecifier(t.identifier('objectAssignShim')),
+            ], t.stringLiteral('object.assign/shim'));
 
             file.set('ensureObjectAssign', () => {
               const [newPath] = path.unshiftContainer('body', assignDeclaration);

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default declare(({
     EMIT_DEPRECATED_DEFAULT_PROPS,
   }) => {
     const defaultProps = SVG_DEFAULT_PROPS_CODE
-      ? 'var props = objectAssignShim()({}, SVG_DEFAULT_PROPS_CODE, overrides);'
+      ? 'var props = objectAssignPolyfill()({}, SVG_DEFAULT_PROPS_CODE, overrides);'
       : '';
     const PROPS_NAME = SVG_DEFAULT_PROPS_CODE ? 'overrides' : 'props';
 
@@ -164,10 +164,10 @@ export default declare(({
             throw new TypeError('the "filename" option is required when transforming code');
           }
 
-          if (!path.scope.hasBinding('object.assign/shim')) {
+          if (!path.scope.hasBinding('object.assign/polyfill')) {
             const assignDeclaration = t.importDeclaration([
-              t.importDefaultSpecifier(t.identifier('objectAssignShim')),
-            ], t.stringLiteral('object.assign/shim'));
+              t.importDefaultSpecifier(t.identifier('objectAssignPolyfill')),
+            ], t.stringLiteral('object.assign/polyfill'));
 
             file.set('ensureObjectAssign', () => {
               const [newPath] = path.unshiftContainer('body', assignDeclaration);

--- a/test/fixtures/test-props.jsx
+++ b/test/fixtures/test-props.jsx
@@ -1,0 +1,5 @@
+import SVG from './close.svg';
+
+export function MyFunctionIcon() {
+  return <SVG />;
+}

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -19,8 +19,8 @@ function assertMatchImport(name, matchRegex) {
 const assertReactImport = assertMatchImport('React', () => /import React from ['"]react['"]/g);
 
 const assertObjectAssignImport = assertMatchImport(
-  'object.assign/implementation',
-  () => /import objectAssign from ['"]object.assign\/implementation['"]/g,
+  'object.assign/shim',
+  () => /import objectAssignShim from ['"]object.assign\/shim['"]/g,
 );
 
 function assertDefaultProps(shouldExist, result) {

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -19,8 +19,8 @@ function assertMatchImport(name, matchRegex) {
 const assertReactImport = assertMatchImport('React', () => /import React from ['"]react['"]/g);
 
 const assertObjectAssignImport = assertMatchImport(
-  'object.assign/shim',
-  () => /import objectAssignShim from ['"]object.assign\/shim['"]/g,
+  'object.assign/polyfill',
+  () => /import objectAssignPolyfill from ['"]object.assign\/polyfill['"]/g,
 );
 
 function assertDefaultProps(shouldExist, result) {


### PR DESCRIPTION
This should close https://github.com/airbnb/babel-plugin-inline-react-svg/issues/126

I've changed the code to:

- Use inline 'defaultProps' in the generated SVG components
- Use `object.assign` to merge the prop overrides (see linked issue)
- Use an option (`emitDeprecatedDefaultProps`) that allows this package users to still keep emitting the `defaultProp` declarations

I've made the option to omit default props an opt-out, so it is a breaking change.. but up for the author to change that to a default false