### PR TITLE
Emit class components to circumvent `defaultProps` warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/parser": "^7.0.0",
+    "create-react-class": "^15.7.0",
     "lodash.isplainobject": "^4.0.6",
     "resolve": "^2.0.0-next.5",
     "svgo": "^2.8.0"

--- a/src/index.js
+++ b/src/index.js
@@ -27,20 +27,18 @@ export default declare(({
     SVG_DEFAULT_PROPS_CODE,
   }) => {
     const namedTemplate = `
-      var SVG_NAME = function SVG_NAME(props) { React.PureComponent.call(this, props); };
-      SVG_NAME.prototype = Object.create(React.PureComponent.prototype);
-      SVG_NAME.prototype.constructor = SVG_NAME;
-      SVG_NAME.prototype.render = function render() { var props = this.props; return SVG_CODE; };
-      ${SVG_DEFAULT_PROPS_CODE ? 'SVG_NAME.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
+      var SVG_NAME = createReactClass({
+        render: function() { var props = this.props; return SVG_CODE; },
+        ${SVG_DEFAULT_PROPS_CODE ? 'getDefaultProps: function() { return SVG_DEFAULT_PROPS_CODE; }' : ''}
+      });
       ${IS_EXPORT ? 'export { SVG_NAME };' : ''}
     `;
     const anonymousTemplate = `
-      var Component = function (props) { React.PureComponent.call(this, props); };
-      Component.prototype = Object.create(React.PureComponent.prototype);
-      Component.prototype.constructor = Component;
-      Component.prototype.render = function render() { var props = this.props; return SVG_CODE; };
-      ${SVG_DEFAULT_PROPS_CODE ? 'Component.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
-      Component.displayName = 'EXPORT_FILENAME';
+      var Component = createReactClass({
+        displayName: EXPORT_FILENAME,
+        render: function() { var props = this.props; return SVG_CODE; },
+        ${SVG_DEFAULT_PROPS_CODE ? 'getDefaultProps: function() { return SVG_DEFAULT_PROPS_CODE; }' : ''}
+      });
       export default Component;
     `;
 
@@ -130,6 +128,8 @@ export default declare(({
 
       file.get('ensureReact')();
       file.set('ensureReact', () => {});
+      file.get('ensureCreateReactClass')();
+      file.set('ensureCreateReactClass', () => {});
     }
     return newPath;
   }
@@ -144,6 +144,20 @@ export default declare(({
           if (typeof filename === 'undefined' && typeof opts.filename !== 'string') {
             throw new TypeError('the "filename" option is required when transforming code');
           }
+
+          if (!path.scope.hasBinding('create-react-class')) {
+            const assignDeclaration = t.importDeclaration([
+              t.importDefaultSpecifier(t.identifier('createReactClass')),
+            ], t.stringLiteral('create-react-class'));
+
+            file.set('ensureCreateReactClass', () => {
+              const [newPath] = path.unshiftContainer('body', assignDeclaration);
+              newPath.get('specifiers').forEach((specifier) => { path.scope.registerBinding('module', specifier); });
+            });
+          } else {
+            file.set('ensureCreateReactClass', () => {});
+          }
+
           if (!path.scope.hasBinding('React')) {
             const reactImportDeclaration = t.importDeclaration([
               t.importDefaultSpecifier(t.identifier('React')),

--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,18 @@ export default declare(({
     SVG_DEFAULT_PROPS_CODE,
   }) => {
     const namedTemplate = `
-      var SVG_NAME = function SVG_NAME(props) { return SVG_CODE; };
+      var SVG_NAME = function SVG_NAME(props) { React.PureComponent.call(this, props); };
+      SVG_NAME.prototype = Object.create(React.PureComponent.prototype);
+      SVG_NAME.prototype.constructor = SVG_NAME;
+      SVG_NAME.prototype.render = function render() { var props = this.props; return SVG_CODE; };
       ${SVG_DEFAULT_PROPS_CODE ? 'SVG_NAME.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
       ${IS_EXPORT ? 'export { SVG_NAME };' : ''}
     `;
     const anonymousTemplate = `
-      var Component = function (props) { return SVG_CODE; };
+      var Component = function (props) { React.PureComponent.call(this, props); };
+      Component.prototype = Object.create(React.PureComponent.prototype);
+      Component.prototype.constructor = Component;
+      Component.prototype.render = function render() { var props = this.props; return SVG_CODE; };
       ${SVG_DEFAULT_PROPS_CODE ? 'Component.defaultProps = SVG_DEFAULT_PROPS_CODE;' : ''}
       Component.displayName = 'EXPORT_FILENAME';
       export default Component;

--- a/test/fixtures/test-props.jsx
+++ b/test/fixtures/test-props.jsx
@@ -1,0 +1,5 @@
+import SVG from './close.svg';
+
+export function MyFunctionIcon() {
+  return <SVG />;
+}

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -4,13 +4,29 @@ import path from 'path';
 import transformTs from '@babel/plugin-transform-typescript';
 import inlineReactSvgPlugin from '../src';
 
-function assertReactImport(result) {
-  const match = result.code.match(/import React from ['"]react['"]/g);
-  if (!match) {
-    throw new Error('no React import found');
+function assertMatchImport(name, matchRegex) {
+  return (result) => {
+    const match = result.code.match(matchRegex());
+    if (!match) {
+      throw new Error(`no ${name} import found`);
+    }
+    if (match.length !== 1) {
+      throw new Error(`more or less than one match found: ${match}\n${result.code}`);
+    }
+  };
+}
+
+const assertReactImport = assertMatchImport('React', () => /import React from ['"]react['"]/g);
+
+function assertDefaultProps(shouldExist, result) {
+  const exists = (/\.defaultProps = /g).test(result.code);
+
+  if (!exists && shouldExist) {
+    throw new Error('defaultProps needs to be present');
   }
-  if (match.length !== 1) {
-    throw new Error(`more or less than one match found: ${match}\n${result.code}`);
+
+  if (exists && !shouldExist) {
+    throw new Error('defaultProps shouldn\'t be present');
   }
 }
 
@@ -29,8 +45,9 @@ transformFile('test/fixtures/test-import.jsx', {
 }, (err, result) => {
   if (err) throw err;
   assertReactImport(result);
+  assertDefaultProps(true, result);
   validateDefaultProps(result);
-  console.log('test/fixtures/test-import.jsx', result.code);
+  console.log('test/fixtures/test-import.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-multiple-svg.jsx', {
@@ -42,8 +59,9 @@ transformFile('test/fixtures/test-multiple-svg.jsx', {
 }, (err, result) => {
   if (err) throw err;
   assertReactImport(result);
+  assertDefaultProps(true, result);
   validateDefaultProps(result);
-  console.log('test/fixtures/test-multiple-svg.jsx', result.code);
+  console.log('test/fixtures/test-multiple-svg.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-no-react.jsx', {
@@ -54,8 +72,9 @@ transformFile('test/fixtures/test-no-react.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-no-react.jsx', result.code);
+  console.log('test/fixtures/test-no-react.jsx\n', result.code);
   assertReactImport(result);
+  assertDefaultProps(true, result);
   validateDefaultProps(result);
 });
 
@@ -78,8 +97,9 @@ transformFile('test/fixtures/test-no-duplicate-react.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-no-duplicate-react.jsx', result.code);
+  console.log('test/fixtures/test-no-duplicate-react.jsx\n', result.code);
   assertReactImport(result);
+  assertDefaultProps(true, result);
   validateDefaultProps(result);
 });
 
@@ -111,7 +131,7 @@ transformFile('test/fixtures/test-no-svg-or-react.js', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-no-svg-or-react.js', result.code);
+  console.log('test/fixtures/test-no-svg-or-react.js\n', result.code);
   if (/React/.test(result.code)) {
     throw new Error('Test failed: React import was present');
   }
@@ -145,7 +165,7 @@ transformFile('test/fixtures/test-dynamic-require.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-dynamic-require.jsx', result.code);
+  console.log('test/fixtures/test-dynamic-require.jsx\n', result.code);
 });
 
 const filename = 'test/fixtures/test-import-read-file.jsx';
@@ -156,7 +176,7 @@ transform(fs.readFileSync(filename), {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-import-read-file.jsx', result.code);
+  console.log('test/fixtures/test-import-read-file.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-export-default.jsx', {
@@ -166,7 +186,7 @@ transformFile('test/fixtures/test-export-default.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-export-default.jsx', result.code);
+  console.log('test/fixtures/test-export-default.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-export-default-as.jsx', {
@@ -182,7 +202,7 @@ transformFile('test/fixtures/test-export-default-as.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-export-default-as.jsx', result.code);
+  console.log('test/fixtures/test-export-default-as.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-export-all-as.jsx', {
@@ -192,7 +212,7 @@ transformFile('test/fixtures/test-export-all-as.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-export-all-as.jsx', result.code);
+  console.log('test/fixtures/test-export-all-as.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-root-styled.jsx', {
@@ -202,7 +222,7 @@ transformFile('test/fixtures/test-root-styled.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-root-styled.jsx', result.code);
+  console.log('test/fixtures/test-root-styled.jsx\n', result.code);
 });
 
 transformFile('test/fixtures/test-commented.jsx', {
@@ -212,7 +232,18 @@ transformFile('test/fixtures/test-commented.jsx', {
   ],
 }, (err, result) => {
   if (err) throw err;
-  console.log('test/fixtures/test-commented.jsx', result.code);
+  console.log('test/fixtures/test-commented.jsx\n', result.code);
+});
+
+transformFile('test/fixtures/test-props.jsx', {
+  presets: ['airbnb'],
+  plugins: [
+    [inlineReactSvgPlugin, { emitDeprecatedDefaultProps: true }],
+  ],
+}, (err, result) => {
+  if (err) throw err;
+  assertDefaultProps(true, result);
+  console.log('test/fixtures/test-props.jsx\n', result.code);
 });
 
 /* TODO: uncomment if babel fixes its parsing for SVGs

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -18,15 +18,17 @@ function assertMatchImport(name, matchRegex) {
 
 const assertReactImport = assertMatchImport('React', () => /import React from ['"]react['"]/g);
 
+const assertCreateReactClassImport = assertMatchImport('createReactClass', () => /import createReactClass from ['"]create-react-class['"]/g);
+
 function assertDefaultProps(shouldExist, result) {
-  const exists = (/\.defaultProps = /g).test(result.code);
+  const exists = (/getDefaultProps:/g).test(result.code);
 
   if (!exists && shouldExist) {
-    throw new Error('defaultProps needs to be present');
+    throw new Error('getDefaultProps needs to be present');
   }
 
   if (exists && !shouldExist) {
-    throw new Error('defaultProps shouldn\'t be present');
+    throw new Error('getDefaultProps shouldn\'t be present');
   }
 }
 
@@ -45,6 +47,7 @@ transformFile('test/fixtures/test-import.jsx', {
 }, (err, result) => {
   if (err) throw err;
   assertReactImport(result);
+  assertCreateReactClassImport(result);
   assertDefaultProps(true, result);
   validateDefaultProps(result);
   console.log('test/fixtures/test-import.jsx\n', result.code);
@@ -59,6 +62,7 @@ transformFile('test/fixtures/test-multiple-svg.jsx', {
 }, (err, result) => {
   if (err) throw err;
   assertReactImport(result);
+  assertCreateReactClassImport(result);
   assertDefaultProps(true, result);
   validateDefaultProps(result);
   console.log('test/fixtures/test-multiple-svg.jsx\n', result.code);
@@ -74,6 +78,7 @@ transformFile('test/fixtures/test-no-react.jsx', {
   if (err) throw err;
   console.log('test/fixtures/test-no-react.jsx\n', result.code);
   assertReactImport(result);
+  assertCreateReactClassImport(result);
   assertDefaultProps(true, result);
   validateDefaultProps(result);
 });
@@ -99,6 +104,7 @@ transformFile('test/fixtures/test-no-duplicate-react.jsx', {
   if (err) throw err;
   console.log('test/fixtures/test-no-duplicate-react.jsx\n', result.code);
   assertReactImport(result);
+  assertCreateReactClassImport(result);
   assertDefaultProps(true, result);
   validateDefaultProps(result);
 });


### PR DESCRIPTION
I'm changing the code emission so that it emits class components so that we don't get `defaultProps` [deprecated warnings](https://github.com/facebook/react/pull/16210) anymore

This is all based on this suggestion here https://github.com/airbnb/babel-plugin-inline-react-svg/pull/129#issuecomment-2525330068 but since that would change the fundamental idea behind the PR (still emit functions but use assign to merge defaultProps + use a flag at the plugin level to preserve behavior), I'm opening a new one

And to make it clear: we're aware that, at least in NextJS, [SSR does not support class components](https://nextjs.org/docs/messages/class-component-in-server-component), but we'll consider that a [fault of NextJS itself](https://github.com/airbnb/babel-plugin-inline-react-svg/pull/129#issuecomment-2544032779).